### PR TITLE
Sécuriser le déploiement prod et ajouter les cibles Makefile prod

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 ## Environment
 
-- **Docker Image Tag**: (e.g., `php8.4-fp1.10.1-base`, `dev`)
+- **Docker Image Tag**: (e.g., `php8.4-fp1.12.7-base`, `dev`)
 - **Magento Version**: (e.g., 2.4.6, 2.4.7, 2.4.8)
 - **Host OS**: (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
 - **Docker Version**: (output of `docker --version`)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,4 +93,7 @@ jobs:
         run: docker compose config --quiet
 
       - name: Validate docker-compose.prod.yml (prod)
+        env:
+          MYSQL_ROOT_PASSWORD: ci-validation-only
+          DB_PASSWORD: ci-validation-only
         run: docker compose -f docker-compose.prod.yml config --quiet

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SHELL := /bin/bash
         composer-install composer-update composer-require \
         mysql mysqldump \
         test-unit test-integration test-api \
+        prod-up prod-down prod-restart prod-build prod-logs prod-status prod-clean prod-clean-all \
         version
 
 # Default target - display help
@@ -112,6 +113,40 @@ composer-update:
 composer-require:
 	./bin/composer require $(PKG)
 
+# --- Production (docker-compose.prod.yml) ---
+
+# Start production containers
+prod-up:
+	docker compose -f docker-compose.prod.yml --profile prod up -d
+
+# Stop production containers
+prod-down:
+	docker compose -f docker-compose.prod.yml --profile prod stop
+
+# Restart production containers
+prod-restart:
+	docker compose -f docker-compose.prod.yml --profile prod restart
+
+# Build production image (Dockerfile.prod, if enabled in docker-compose.prod.yml)
+prod-build:
+	docker compose -f docker-compose.prod.yml build
+
+# Follow production container logs
+prod-logs:
+	docker compose -f docker-compose.prod.yml --profile prod logs -f
+
+# Show production container status
+prod-status:
+	docker compose -f docker-compose.prod.yml --profile prod ps
+
+# Remove production containers
+prod-clean:
+	docker compose -f docker-compose.prod.yml --profile prod down
+
+# Remove production containers, volumes and networks
+prod-clean-all:
+	docker compose -f docker-compose.prod.yml --profile prod down -v
+
 # Access MySQL CLI
 mysql:
 	./bin/mysql
@@ -172,6 +207,16 @@ help:
 	@echo "🗄️  Database:"
 	@echo "  make mysql             - Access MySQL CLI"
 	@echo "  make mysqldump         - Dump database"
+	@echo ""
+	@echo "🏭 Production (docker-compose.prod.yml):"
+	@echo "  make prod-up           - Start production containers"
+	@echo "  make prod-down         - Stop production containers"
+	@echo "  make prod-restart      - Restart production containers"
+	@echo "  make prod-build        - Build production image"
+	@echo "  make prod-logs         - Follow production logs"
+	@echo "  make prod-status       - Show production container status"
+	@echo "  make prod-clean        - Remove production containers"
+	@echo "  make prod-clean-all    - Remove production containers + volumes"
 	@echo ""
 	@echo "🧪 Testing:"
 	@echo "  make test-unit         - Run unit tests"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 services:
   app:
     # Option 1: Use pre-built image (default)
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
     # Option 2: Build production image with compiled DI and static content
     # build:
     #   context: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,10 @@ services:
     environment:
       SERVER_NAME: ${SERVER_NAME:-magento.com}
       MAGENTO_RUN_MODE: production
+    # This bind-mount only applies to Option 1 (base image above).
+    # If you switch to Option 2 (build with docker/images/app/Dockerfile),
+    # the image already contains compiled code and static content —
+    # remove this volume, otherwise it will overwrite/shadow the built app.
     volumes:
       - ./src:/var/www/html
     ports:
@@ -44,10 +48,10 @@ services:
       - prod
     env_file: env/mariadb.env
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env before deploying to production}
       MYSQL_DATABASE: ${DB_NAME:-magento}
       MYSQL_USER: ${DB_USER:-magento}
-      MYSQL_PASSWORD: ${DB_PASSWORD:-magento}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in .env before deploying to production}
     volumes:
       - db-data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - traefik.http.routers.traefik.service=api@internal
 
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     container_name: ${PROJECT_NAME:-magento}-app
     user: www-data
     profiles:

--- a/docker/images/app/Dockerfile
+++ b/docker/images/app/Dockerfile
@@ -11,7 +11,7 @@
 #                --build-arg STATIC_CONTENT_LANGUAGES="en_US fr_FR" ...
 
 # Stage 1: Build
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base AS builder
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base AS builder
 
 ARG MAGENTO_ROOT=/var/www/html
 # Static content deployment configuration
@@ -76,7 +76,7 @@ RUN rm -rf var/cache/* var/page_cache/* generated/code/* generated/metadata/* pu
  && if [ -f app/etc/env.php.bak ]; then mv app/etc/env.php.bak app/etc/env.php; fi
 
 # Stage 2: Production image
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
 
 ARG MAGENTO_ROOT=/var/www/html
 

--- a/docs/examples/production-dockerfile.md
+++ b/docs/examples/production-dockerfile.md
@@ -2,6 +2,20 @@
 
 This example shows how to create a production-ready Magento Docker image using the FrankenPHP base image.
 
+## Required Environment Variables
+
+`docker-compose.prod.yml` will refuse to start unless these are set in `.env`
+(no weak defaults are provided for production):
+
+```bash
+MYSQL_ROOT_PASSWORD=change-me
+DB_PASSWORD=change-me
+```
+
+Manage the stack with `make prod-up`, `make prod-down`, `make prod-logs`,
+`make prod-status`, `make prod-build`, `make prod-clean` / `prod-clean-all`
+(see `make help`), or call `docker compose -f docker-compose.prod.yml` directly.
+
 ## Quick Start
 
 A ready-to-use production Dockerfile is provided at `docker/images/app/Dockerfile`:
@@ -30,6 +44,9 @@ services:
     build:
       context: .
       dockerfile: docker/images/app/Dockerfile
+    # Remove the `./src:/var/www/html` volume when using this option: the
+    # built image already contains the compiled code and static content,
+    # and the bind-mount would shadow it.
 ```
 
 ## docker/images/app/Dockerfile

--- a/docs/examples/production-dockerfile.md
+++ b/docs/examples/production-dockerfile.md
@@ -39,7 +39,7 @@ Or use docker-compose by uncommenting the build section in `docker-compose.prod.
 services:
   app:
     # Option 1: Use pre-built image (default)
-    # image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+    # image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
     # Option 2: Build production image with compiled DI and static content
     build:
       context: .
@@ -72,7 +72,7 @@ Or use docker-compose by uncommenting the build section in `docker-compose.prod.
 services:
   app:
     # Option 1: Use pre-built image (default)
-    # image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+    # image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
     # Option 2: Build production image with compiled DI and static content
     build:
       context: .
@@ -216,7 +216,7 @@ The `docker/images/app/Dockerfile` already uses a multi-stage build. Here's the 
 
 ```dockerfile
 # Stage 1: Build
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10-dev AS builder
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev AS builder
 
 WORKDIR /var/www/html
 COPY --chown=www-data:www-data . .
@@ -227,7 +227,7 @@ RUN php -d memory_limit=4G bin/magento setup:di:compile
 RUN php -d memory_limit=4G bin/magento setup:static-content:deploy -f --jobs=16
 
 # Stage 2: Production
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
 
 WORKDIR /var/www/html
 COPY --from=builder --chown=www-data:www-data /var/www/html .

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,12 +48,18 @@ nano .env
 ```bash
 # Development
 docker compose up -d
+# or: make up
 
-# Production
-docker compose -f docker-compose.prod.yml up -d
+# Production — first set MYSQL_ROOT_PASSWORD and DB_PASSWORD in .env
+# (docker-compose.prod.yml refuses to start without them)
+docker compose -f docker-compose.prod.yml --profile prod up -d
+# or: make prod-up
 ```
 
-### 4. Access Your Services
+> See [Production Deployment](examples/production-dockerfile.md) for required
+> environment variables and the full list of `make prod-*` commands.
+
+### 5. Access Your Services
 
 | Service | URL |
 |---------|-----|

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -4,7 +4,7 @@ This guide explains how to configure and use Xdebug for debugging your Magento 2
 
 ## Prerequisites
 
-- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.10.1-dev`)
+- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.12.7-dev`)
 - PHPStorm, VS Code, or another IDE with Xdebug support
 
 ## Default Configuration
@@ -36,7 +36,7 @@ You can customize Xdebug settings using environment variables. These are process
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     environment:
       XDEBUG_MODE: debug
       XDEBUG_CLIENT_HOST: host.docker.internal
@@ -62,7 +62,7 @@ Make sure your `docker-compose.yml` uses the dev image:
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     # or simply use the 'dev' tag:
     # image: mohelmrabet/magento-frankenphp:dev
 ```

--- a/env/magento.env.example
+++ b/env/magento.env.example
@@ -2,3 +2,7 @@ PROJECT_NAME=magento
 SERVER_NAME=magento.localhost
 BASE_URL=https://magento.localhost/
 
+# Required in production (docker-compose.prod.yml refuses to start without them):
+# MYSQL_ROOT_PASSWORD=change-me
+# DB_PASSWORD=change-me
+

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,22 @@
         "dependencies",
         "traefik"
       ]
+    },
+    {
+      "description": "Enable magento-frankenphp image updates",
+      "matchPackageNames": [
+        "mohelmrabet/magento-frankenphp"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "enabled": true,
+      "groupName": "magento-frankenphp",
+      "automerge": false,
+      "labels": [
+        "dependencies",
+        "magento-frankenphp"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `docker-compose.prod.yml` exige désormais explicitement `MYSQL_ROOT_PASSWORD` et `DB_PASSWORD` (plus de fallback faible `root`/`magento`)
- Clarification par commentaire du bind-mount `./src` vis-à-vis de l'option build multi-stage (Dockerfile.prod)
- Ajout des cibles `make prod-up/down/restart/build/logs/status/clean/clean-all`

## Test plan
- [x] `docker compose -f docker-compose.prod.yml config -q` échoue sans `MYSQL_ROOT_PASSWORD`/`DB_PASSWORD`
- [x] `docker compose -f docker-compose.prod.yml config -q` réussit une fois ces variables définies
- [x] `make help` affiche correctement la nouvelle section prod